### PR TITLE
Remove invalid import of library BuildConfig

### DIFF
--- a/app/src/main/kotlin/nl/q42/template/MainApplication.kt
+++ b/app/src/main/kotlin/nl/q42/template/MainApplication.kt
@@ -1,7 +1,6 @@
 package nl.q42.template
 
 import android.app.Application
-import com.ramcosta.composedestinations.BuildConfig
 import dagger.hilt.android.HiltAndroidApp
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier


### PR DESCRIPTION
Remove invalid import of library BuildConfig in the MainApplication, it auto uses the project this way, but only if you compiled the project before. Else it will prompt for an import ;)