### PR TITLE
CHANGE centralized jvm version for all modules

### DIFF
--- a/build.config.jvm.gradle
+++ b/build.config.jvm.gradle
@@ -1,0 +1,11 @@
+android {
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmTarget.get()))
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+}

--- a/build.module.feature-and-app.gradle
+++ b/build.module.feature-and-app.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'kotlin-android'
 
+apply from: "$rootDir/build.config.jvm.gradle"
 apply from: "$rootDir/build.dep.di.gradle"
 apply from: "$rootDir/build.dep.compose.gradle"
 
@@ -18,13 +19,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility(JavaVersion.VERSION_17)
-        targetCompatibility(JavaVersion.VERSION_17)
-    }
-    kotlinOptions {
-        jvmTarget = libs.versions.jvmTarget.get()
-    }
     buildFeatures {
         compose = true
     }

--- a/build.module.library.gradle
+++ b/build.module.library.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'kotlin-android'
 
+apply from: "$rootDir/build.config.jvm.gradle"
 apply from: "$rootDir/build.dep.di.gradle"
 
 android {
@@ -8,13 +9,6 @@ android {
     defaultConfig {
         targetSdk = rootProject.ext.targetSdkVersion
         minSdk = rootProject.ext.minSdkVersion
-    }
-    compileOptions {
-        sourceCompatibility(JavaVersion.VERSION_17)
-        targetCompatibility(JavaVersion.VERSION_17)
-    }
-    kotlinOptions {
-        jvmTarget = libs.versions.jvmTarget.get()
     }
 }
 


### PR DESCRIPTION
## Why is this important?
- added toolchain function so that all gradle tasks use the same java version
- centralized the jvm versioning logic
