### PR TITLE
ADD Junit testing

### DIFF
--- a/build.module.feature-and-app.gradle
+++ b/build.module.feature-and-app.gradle
@@ -42,4 +42,10 @@ dependencies {
     implementation(libs.napier)
     implementation(libs.activityCompose)
     implementation(libs.hiltNavigationCompose)
+
+    testImplementation libs.junit
+    testImplementation libs.kotlinx.coroutines.test
+    testImplementation libs.turbine
+    testImplementation libs.mockk.android
+    testImplementation libs.mockk.agent
 }

--- a/feature/home/src/test/kotlin/nl/q42/template/presentation/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/kotlin/nl/q42/template/presentation/home/HomeViewModelTest.kt
@@ -1,0 +1,56 @@
+package nl.q42.template.presentation.home
+
+import app.cash.turbine.test
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import nl.q42.template.actionresult.domain.ActionResult
+import nl.q42.template.domain.user.model.User
+import nl.q42.template.domain.user.usecase.GetUserUseCase
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+
+class HomeViewModelTest(){
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+    @Test
+    fun `WHEN I subscribe to uiState with a slow UserUseCase THEN I get the loading state and expected email address`() = runTest{
+        val getUserUseCaseMock: GetUserUseCase = mockk()
+        coEvery {getUserUseCaseMock.invoke() }.coAnswers {
+            // demonstration of test scheduler. This does not actually block the test for 4 seconds
+            delay(4.seconds)
+            ActionResult.Success(User("test@test.com"))
+        }
+
+        val viewModel = HomeViewModel(getUserUseCaseMock, mockk())
+
+        viewModel.uiState.test {
+            val expectedData: HomeViewState = HomeViewState.Data("test@test.com")
+
+            assertEquals(HomeViewState.Loading, awaitItem())
+            assertEquals(expectedData, awaitItem())
+        }
+    }
+
+    @Test
+    fun `WHEN I subscribe to uiState with a fast UserUseCase THEN I get expected email address immediately`() = runTest{
+        val getUserUseCaseMock: GetUserUseCase = mockk()
+        coEvery { getUserUseCaseMock.invoke() }.returns(
+            ActionResult.Success(User("test@test.com")
+        ))
+
+
+        val viewModel = HomeViewModel(getUserUseCaseMock, mockk())
+
+        viewModel.uiState.test {
+            val expectedData: HomeViewState = HomeViewState.Data("test@test.com")
+            assertEquals(expectedData, awaitItem())
+        }
+    }
+
+}

--- a/feature/home/src/test/kotlin/nl/q42/template/presentation/home/MainDispatcherRule.kt
+++ b/feature/home/src/test/kotlin/nl/q42/template/presentation/home/MainDispatcherRule.kt
@@ -1,0 +1,22 @@
+package nl.q42.template.presentation.home
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+// Reusable JUnit4 TestRule to override the Main dispatcher
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,10 +23,7 @@ activityCompose = "1.6.1"
 hiltNavigationCompose = "1.0.0"
 composeLifecycle = "2.6.0-beta01"
 turbine = "1.0.0"
-#androidx-test-ext-junit = "1.1.5"
-#espresso-core = "3.5.1"
 appcompat = "1.6.1"
-#material = "1.9.0"
 
 [libraries]
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -57,10 +54,6 @@ activityCompose = { module = "androidx.activity:activity-compose", version.ref =
 hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 composeLifecycle = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecycle" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-#androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
-#espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
-#appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-#material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
 androidxCore = "1.9.0"
 androidxLifecycle = "2.5.1"
+kotlinxCoroutinesTest = "1.7.3"
+junit = "4.13.2"
+mockkAndroid = "1.13.5"
 kotlinCompilerExtensionVersion = "1.4.4"
 jvmTarget = "17"
 kotlin = "1.8.10"
@@ -19,12 +22,21 @@ composePlatform = "2022.10.00"
 activityCompose = "1.6.1"
 hiltNavigationCompose = "1.0.0"
 composeLifecycle = "2.6.0-beta01"
+turbine = "1.0.0"
+#androidx-test-ext-junit = "1.1.5"
+#espresso-core = "3.5.1"
+appcompat = "1.6.1"
+#material = "1.9.0"
 
 [libraries]
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidxLifecycleKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hiltKapt = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAndroid" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 moshiRetrofitConverter = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
@@ -44,6 +56,11 @@ composePlatform = { module = "androidx.compose:compose-bom", version.ref = "comp
 activityCompose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 composeLifecycle = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecycle" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+#androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
+#espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+#appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+#material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 
 [plugins]


### PR DESCRIPTION
## Why is this important?
Unit testing Flows is not always straightforward, let's give an example and set up the dependencies

## Any review notes?
Uses Junit java dependencies directly, ie. `import junit.framework.TestCase.assertEquals`
I think kotlin-test would be nicer, but I'm not sure how to add the dependency
https://kotlinlang.org/docs/jvm-test-using-junit.html (note this uses junit5 and we are using junit4)

It is unclear whether junit5 is supported in Android, don't think so: https://issuetracker.google.com/issues/127100532