### PR TITLE
CHANGE expose vm's ui state as stateflow

### DIFF
--- a/core/navigation/src/main/kotlin/nl/q42/template/navigation/viewmodel/InitNavigator.kt
+++ b/core/navigation/src/main/kotlin/nl/q42/template/navigation/viewmodel/InitNavigator.kt
@@ -14,7 +14,7 @@ import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 @Composable
 fun InitNavigator(destinationsNavigator: DestinationsNavigator, routeNavigator: RouteNavigator) {
 
-    val viewState by routeNavigator.navigationState.collectAsStateWithLifecycle(initialValue = NavigationState.Idle)
+    val viewState by routeNavigator.navigationState.collectAsStateWithLifecycle()
     LaunchedEffect(viewState) {
         updateNavigationState(destinationsNavigator, viewState, routeNavigator::onNavigated)
     }

--- a/feature/home/src/main/kotlin/nl/q42/template/presentation/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/presentation/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import nl.q42.template.actionresult.data.handleAction
@@ -21,7 +22,7 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel(), RouteNavigator by navigator {
 
     private val _uiState = MutableStateFlow<HomeViewState>(HomeViewState.Empty)
-    val uiState: StateFlow<HomeViewState> = _uiState
+    val uiState: StateFlow<HomeViewState> = _uiState.asStateFlow()
 
     init {
         loadUser()

--- a/feature/home/src/main/kotlin/nl/q42/template/presentation/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/presentation/home/HomeViewModel.kt
@@ -3,8 +3,8 @@ package nl.q42.template.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import nl.q42.template.actionresult.data.handleAction
@@ -21,7 +21,7 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel(), RouteNavigator by navigator {
 
     private val _uiState = MutableStateFlow<HomeViewState>(HomeViewState.Empty)
-    val uiState: Flow<HomeViewState> = _uiState
+    val uiState: StateFlow<HomeViewState> = _uiState
 
     init {
         loadUser()

--- a/feature/home/src/main/kotlin/nl/q42/template/presentation/home/second/HomeSecondViewModel.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/presentation/home/second/HomeSecondViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import nl.q42.template.navigation.viewmodel.RouteNavigator
 import javax.inject.Inject
 
@@ -18,7 +19,7 @@ class HomeSecondViewModel @Inject constructor(
     private val titleParam = savedStateHandle.get<String>("title") ?: throw IllegalArgumentException("title required")
 
     private val _uiState = MutableStateFlow<HomeSecondViewState>(HomeSecondViewState(titleParam))
-    val uiState: StateFlow<HomeSecondViewState> = _uiState
+    val uiState: StateFlow<HomeSecondViewState> = _uiState.asStateFlow()
 
     fun onBackClicked() {
         navigateUp()

--- a/feature/home/src/main/kotlin/nl/q42/template/presentation/home/second/HomeSecondViewModel.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/presentation/home/second/HomeSecondViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import nl.q42.template.navigation.viewmodel.RouteNavigator
 import javax.inject.Inject
 
@@ -17,7 +18,7 @@ class HomeSecondViewModel @Inject constructor(
     private val titleParam = savedStateHandle.get<String>("title") ?: throw IllegalArgumentException("title required")
 
     private val _uiState = MutableStateFlow<HomeSecondViewState>(HomeSecondViewState(titleParam))
-    val uiState: Flow<HomeSecondViewState> = _uiState
+    val uiState: StateFlow<HomeSecondViewState> = _uiState
 
     fun onBackClicked() {
         navigateUp()

--- a/feature/home/src/main/kotlin/nl/q42/template/ui/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/ui/home/HomeScreen.kt
@@ -22,6 +22,6 @@ fun HomeScreen(
 
     OnLifecycleResume(viewModel::onScreenResumed)
 
-    val viewState by viewModel.uiState.collectAsStateWithLifecycle(initialValue = HomeViewState.Empty)
+    val viewState by viewModel.uiState.collectAsStateWithLifecycle()
     HomeContent(viewState, viewModel::onLoadClicked, viewModel::onOpenSecondScreenClicked, viewModel::onOpenOnboardingClicked)
 }

--- a/feature/home/src/main/kotlin/nl/q42/template/ui/home/second/HomeSecondScreen.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/ui/home/second/HomeSecondScreen.kt
@@ -16,7 +16,6 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import nl.q42.template.navigation.viewmodel.InitNavigator
 import nl.q42.template.presentation.home.second.HomeSecondViewModel
-import nl.q42.template.presentation.home.second.HomeSecondViewState
 
 @Destination
 @Composable
@@ -33,7 +32,7 @@ fun HomeSecondScreen(
 
     InitNavigator(navigator, viewModel) // enables viewModel to navigate to other screens
 
-    val viewState by viewModel.uiState.collectAsStateWithLifecycle(initialValue = HomeSecondViewState(""))
+    val viewState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier.fillMaxSize(),

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/presentation/onboarding/start/OnboardingStartViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/presentation/onboarding/start/OnboardingStartViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import nl.q42.template.navigation.viewmodel.RouteNavigator
 import javax.inject.Inject
 
@@ -15,7 +16,7 @@ class OnboardingStartViewModel @Inject constructor(
 ) : ViewModel(), RouteNavigator by navigator {
 
     private val _uiState = MutableStateFlow(OnboardingStartViewState("start"))
-    val uiState: Flow<OnboardingStartViewState> = _uiState
+    val uiState: StateFlow<OnboardingStartViewState> = _uiState
 
     fun onBackClicked() {
         navigateUp()

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/presentation/onboarding/start/OnboardingStartViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/presentation/onboarding/start/OnboardingStartViewModel.kt
@@ -3,9 +3,9 @@ package nl.q42.template.presentation.onboarding.start
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import nl.q42.template.navigation.viewmodel.RouteNavigator
 import javax.inject.Inject
 
@@ -16,7 +16,7 @@ class OnboardingStartViewModel @Inject constructor(
 ) : ViewModel(), RouteNavigator by navigator {
 
     private val _uiState = MutableStateFlow(OnboardingStartViewState("start"))
-    val uiState: StateFlow<OnboardingStartViewState> = _uiState
+    val uiState: StateFlow<OnboardingStartViewState> = _uiState.asStateFlow()
 
     fun onBackClicked() {
         navigateUp()

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/ui/onboarding/start/OnboardingStartScreen.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/ui/onboarding/start/OnboardingStartScreen.kt
@@ -27,7 +27,7 @@ fun OnboardingStartScreen(
 
     InitNavigator(navigator, viewModel) // enables viewModel to navigate to other screens
 
-    val viewState by viewModel.uiState.collectAsStateWithLifecycle(initialValue = OnboardingStartViewState(""))
+    val viewState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
expose vm's ui state as stateflow:
- to not have to set a default twice
- this also solves a possible flickering default state bug, when navigating to this screen from backstack and a state change from the viewmodel is preceded by the default state for a split second.
