### PR TITLE
Feature: Use type safe view states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle
+.kotlin
 /local.properties
 /.idea/caches
 /.idea/libraries

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/AndroidProjectSystem.xml
 .DS_Store
 /build
 /captures

--- a/data/main/src/main/kotlin/nl/q42/template/data/main/local/UserLocalDataSource.kt
+++ b/data/main/src/main/kotlin/nl/q42/template/data/main/local/UserLocalDataSource.kt
@@ -1,6 +1,7 @@
 package nl.q42.template.data.main.local
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import nl.q42.template.data.main.local.model.UserEntity
@@ -8,13 +9,13 @@ import javax.inject.Inject
 
 internal class UserLocalDataSource @Inject constructor() {
 
-    private val userFlow = MutableStateFlow<UserEntity?>(null) // this is dummy code, replace it with your own local storage implementation.
+    private val userFlow = MutableSharedFlow<UserEntity?>() // this is dummy code, replace it with your own local storage implementation.
 
-    fun setUser(userEntity: UserEntity) {
+    suspend fun setUser(userEntity: UserEntity) {
 
         // usually you store in DataStore or DB here...
 
-        userFlow.update { userEntity } // this is dummy code, replace it with your own local storage implementation.
+        userFlow.emit(userEntity) // this is dummy code, replace it with your own local storage implementation.
     }
 
     fun getUserFlow(): Flow<UserEntity?> = userFlow

--- a/feature/home/src/main/kotlin/nl/q42/template/home/main/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/home/main/presentation/HomeViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import nl.q42.template.actionresult.data.handleAction
 import nl.q42.template.domain.main.usecase.FetchUserUseCase
@@ -29,7 +28,7 @@ class HomeViewModel @Inject constructor(
     private val navigator: RouteNavigator,
 ) : ViewModel(), RouteNavigator by navigator {
 
-    private val _uiState = MutableStateFlow<HomeViewState>(HomeViewState())
+    private val _uiState = MutableStateFlow<HomeViewState>(HomeViewState.Loading)
     val uiState: StateFlow<HomeViewState> = _uiState.asStateFlow()
 
     init {
@@ -56,23 +55,21 @@ class HomeViewModel @Inject constructor(
     fun fetchUser() {
         viewModelScope.launch {
 
-            _uiState.update { it.copy(showError = false, isLoading = true) }
+            _uiState.value = HomeViewState.Loading
 
             handleAction(
                 action = fetchUserUseCase(),
-                onError = { _uiState.update { it.copy(showError = true, isLoading = false) } },
-                onSuccess = { _uiState.update { it.copy(isLoading = false) } },
+                onError = { _uiState.value = HomeViewState.Error },
+                onSuccess = {},
             )
         }
     }
 
     private fun startObservingUserChanges() {
         getUserFlowUseCase().filterNotNull().onEach { user ->
-            _uiState.update {
-                it.copy(
-                    userEmailTitle = ViewStateString.Res(R.string.emailTitle, user.email.value)
-                )
-            }
+            _uiState.value = HomeViewState.Content(
+                userEmailTitle = ViewStateString.Res(R.string.emailTitle, user.email.value)
+            )
         }.launchIn(viewModelScope)
     }
 }

--- a/feature/home/src/main/kotlin/nl/q42/template/home/main/presentation/HomeViewState.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/home/main/presentation/HomeViewState.kt
@@ -2,8 +2,8 @@ package nl.q42.template.home.main.presentation
 
 import nl.q42.template.ui.presentation.ViewStateString
 
-data class HomeViewState(
-    val userEmailTitle: ViewStateString? = null,
-    val isLoading: Boolean = false,
-    val showError: Boolean = false,
-)
+sealed interface HomeViewState {
+    data class Content(val userEmailTitle: ViewStateString) : HomeViewState
+    data object Loading : HomeViewState
+    data object Error : HomeViewState
+}

--- a/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
@@ -36,13 +36,16 @@ internal fun HomeContent(
         horizontalAlignment = CenterHorizontally,
     ) {
 
-        /**
-         * This is dummy. Use the strings file IRL.
-         */
-        viewState.userEmailTitle?.get()?.let { Text(text = it) }
-
-        if (viewState.isLoading) CircularProgressIndicator()
-        if (viewState.showError) BodyText("Error", TemplateTheme.colors.error)
+        when(viewState) {
+            is HomeViewState.Content -> {
+                /**
+                 * This is dummy. Use the strings file IRL.
+                 */
+                Text(text = viewState.userEmailTitle.get())
+            }
+            is HomeViewState.Loading -> CircularProgressIndicator()
+            is HomeViewState.Error -> BodyText("Error", TemplateTheme.colors.error)
+        }
 
         Spacer(Modifier.height(Dimens.componentSpacingVertical))
 
@@ -66,7 +69,7 @@ internal fun HomeContent(
 @Composable
 private fun HomeContentErrorPreview() {
     PreviewTemplateTheme {
-        HomeContent(HomeViewState(showError = true), {}, {}, {})
+        HomeContent(HomeViewState.Error, {}, {}, {})
     }
 }
 
@@ -74,7 +77,7 @@ private fun HomeContentErrorPreview() {
 @Composable
 private fun HomeContentLoadingPreview() {
     PreviewTemplateTheme {
-        HomeContent(HomeViewState(isLoading = true), {}, {}, {})
+        HomeContent(HomeViewState.Loading, {}, {}, {})
     }
 }
 
@@ -82,6 +85,6 @@ private fun HomeContentLoadingPreview() {
 @Composable
 private fun HomeContentEmptyPreview() {
     PreviewTemplateTheme {
-        HomeContent(HomeViewState(userEmailTitle = "preview@preview.com".toViewStateString()), {}, {}, {})
+        HomeContent(HomeViewState.Content(userEmailTitle = "preview@preview.com".toViewStateString()), {}, {}, {})
     }
 }

--- a/feature/home/src/test/kotlin/nl/q42/template/home/main/presentation/HomeViewModelTest.kt
+++ b/feature/home/src/test/kotlin/nl/q42/template/home/main/presentation/HomeViewModelTest.kt
@@ -43,7 +43,7 @@ class HomeViewModelTest {
         )
 
         viewModel.uiState.test {
-            assertTrue(awaitItem().isLoading)
+            assertTrue(awaitItem() == HomeViewState.Loading)
         }
     }
 
@@ -65,7 +65,7 @@ class HomeViewModelTest {
         )
 
         viewModel.uiState.test {
-            assertTrue(awaitItem().showError)
+            assertTrue(awaitItem() == HomeViewState.Error)
         }
     }
 }


### PR DESCRIPTION
## Why is this important?
To encourage the use of ViewStates that avoid illegal states (e.g. HomeViewState(userEmailTitle = "test@test.com", isLoading = true, showError = true) 🤯😕)

## Notes
The **MutableStateFlow** in the repo needs to be a **MutableSharedFlow**, otherwise it won't emit new events when the same data is received from the backend, in this case we want to get updates and let the UI do the diffs.