### PR TITLE
Onboarding Package Structure Fix

### DIFF
--- a/app/src/main/kotlin/nl/q42/template/navigation/NavGraphs.kt
+++ b/app/src/main/kotlin/nl/q42/template/navigation/NavGraphs.kt
@@ -4,7 +4,7 @@ import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.ramcosta.composedestinations.spec.NavGraphSpec
 import nl.q42.template.home.destinations.HomeScreenDestination
 import nl.q42.template.home.destinations.HomeSecondScreenDestination
-import nl.q42.template.onboarding.ui.start.destinations.OnboardingStartScreenDestination
+import nl.q42.template.onboarding.start.ui.destinations.OnboardingStartScreenDestination
 
 /**
  *

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/presentation/start/OnboardingStartViewState.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/presentation/start/OnboardingStartViewState.kt
@@ -1,3 +1,0 @@
-package nl.q42.template.onboarding.presentation.start
-
-class OnboardingStartViewState(val title: String)

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/presentation/OnboardingStartViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/presentation/OnboardingStartViewModel.kt
@@ -1,4 +1,4 @@
-package nl.q42.template.onboarding.presentation.start
+package nl.q42.template.onboarding.start.presentation
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/presentation/OnboardingStartViewState.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/presentation/OnboardingStartViewState.kt
@@ -1,0 +1,3 @@
+package nl.q42.template.onboarding.start.presentation
+
+class OnboardingStartViewState(val title: String)

--- a/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/ui/OnboardingStartScreen.kt
+++ b/feature/onboarding/src/main/kotlin/nl/q42/template/onboarding/start/ui/OnboardingStartScreen.kt
@@ -1,4 +1,4 @@
-package nl.q42.template.onboarding.ui.start
+package nl.q42.template.onboarding.start.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,7 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import nl.q42.template.navigation.viewmodel.InitNavigator
-import nl.q42.template.onboarding.presentation.start.OnboardingStartViewModel
+import nl.q42.template.onboarding.start.presentation.OnboardingStartViewModel
 
 @Destination
 @Composable


### PR DESCRIPTION
Onboarding-Package-Structure-Fix

## Why is this important?
Whilst working on the Digital Museum Pass with Nino, we have a cookie cutter script that is able to copy screens / and either make a new feature to copy the screen into or copy the screen into an existing feature. Whilst working with it i noticed the package structure of the onboarding feature was inconsistent with the home feature. 

This PR fixes that structure.

## Notes
