### PR TITLE
refactor-app-theme-to-template-theme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -269,7 +269,7 @@ or replacement parameter logic.
 
 Use `@PreviewLightDark` to generate two previews from one function, one dark and one light. You
 probably also want to
-wrap your preview content with a `PreviewAppTheme{..}` so that your previews have the correct theme
+wrap your preview content with a `PreviewTemplateTheme{..}` so that your previews have the correct theme
 background.
 
 ### BuildConfig

--- a/app/src/main/kotlin/nl/q42/template/MainActivity.kt
+++ b/app/src/main/kotlin/nl/q42/template/MainActivity.kt
@@ -10,8 +10,8 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import nl.q42.template.navigation.AppNavigation
 import nl.q42.template.navigation.NavGraphs
-import nl.q42.template.ui.compose.composables.widgets.AppSurface
-import nl.q42.template.ui.theme.AppTheme
+import nl.q42.template.ui.compose.composables.widgets.TemplateSurface
+import nl.q42.template.ui.theme.TemplateTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -21,11 +21,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
 
-            AppTheme {
+            TemplateTheme {
 
                 val navController = rememberNavController()
 
-                AppSurface (
+                TemplateSurface (
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     AppNavigation(navController = navController, navGraph = NavGraphs.root)

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/BodyText.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/BodyText.kt
@@ -3,22 +3,22 @@ package nl.q42.template.ui.compose.composables.text
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import nl.q42.template.ui.theme.AppTheme
 import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
-fun BodyText(text: String, color: Color = AppTheme.colors.textPrimary) {
+fun BodyText(text: String, color: Color = TemplateTheme.colors.textPrimary) {
     Text(
         text = text,
         color = color,
-        style = AppTheme.typography.body
+        style = TemplateTheme.typography.body
     )
 }
 
 @Composable
 @PreviewLightDark
 private fun BodyTextPreview() {
-    AppTheme {
+    TemplateTheme {
         BodyText("Body text")
     }
 }

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/H1Text.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/H1Text.kt
@@ -3,22 +3,22 @@ package nl.q42.template.ui.compose.composables.text
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import nl.q42.template.ui.theme.AppTheme
 import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
-fun H1Text(text: String, color: Color = AppTheme.colors.textPrimary) {
+fun H1Text(text: String, color: Color = TemplateTheme.colors.textPrimary) {
     Text(
         text = text,
         color = color,
-        style = AppTheme.typography.h1
+        style = TemplateTheme.typography.h1
     )
 }
 
 @Composable
 @PreviewLightDark
 private fun H1TextPreview() {
-    AppTheme {
+    TemplateTheme {
         H1Text("H1 text")
     }
 }

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateButton.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateButton.kt
@@ -4,8 +4,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import nl.q42.template.ui.theme.AppTheme
 import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
 fun TemplateButton(text: String, enabled: Boolean = true, onClick: () -> Unit) {
@@ -13,16 +13,16 @@ fun TemplateButton(text: String, enabled: Boolean = true, onClick: () -> Unit) {
         onClick = onClick,
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(
-            containerColor = AppTheme.colors.accent,
-            contentColor = AppTheme.colors.buttonText,
-            disabledContentColor = AppTheme.colors.buttonText.copy(alpha = 0.5f),
-            disabledContainerColor = AppTheme.colors.accent.copy(alpha = 0.5f)
+            containerColor = TemplateTheme.colors.accent,
+            contentColor = TemplateTheme.colors.buttonText,
+            disabledContentColor = TemplateTheme.colors.buttonText.copy(alpha = 0.5f),
+            disabledContainerColor = TemplateTheme.colors.accent.copy(alpha = 0.5f)
         )
     ) {
         Text(
             text = text,
-            style = AppTheme.typography.body,
-            color = AppTheme.colors.buttonText
+            style = TemplateTheme.typography.body,
+            color = TemplateTheme.colors.buttonText
         )
     }
 }
@@ -30,7 +30,7 @@ fun TemplateButton(text: String, enabled: Boolean = true, onClick: () -> Unit) {
 @Composable
 @PreviewLightDark
 private fun TemplateButtonPreview() {
-    AppTheme {
+    TemplateTheme {
         TemplateButton("Button",) {}
     }
 }

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateSurface.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateSurface.kt
@@ -4,23 +4,23 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import nl.q42.template.ui.theme.AppTheme
 import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
-fun AppSurface(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+fun TemplateSurface(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
     Surface(
         modifier = modifier,
-        color = AppTheme.colors.surface,
-        contentColor = AppTheme.colors.textPrimary,
+        color = TemplateTheme.colors.surface,
+        contentColor = TemplateTheme.colors.textPrimary,
         content = content
     )
 }
 
 @Composable
 @PreviewLightDark
-private fun AppSurfacePreview() {
-    AppTheme {
-        AppSurface(Modifier.fillMaxSize()) {}
+private fun TemplateSurfacePreview() {
+    TemplateTheme {
+        TemplateSurface(Modifier.fillMaxSize()) {}
     }
 }

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorScheme.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorScheme.kt
@@ -2,7 +2,7 @@ package nl.q42.template.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-interface AppColorScheme {
+interface TemplateColorScheme {
     val buttonText: Color
     val accent: Color
     val textPrimary: Color

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorSchemeDark.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorSchemeDark.kt
@@ -2,7 +2,7 @@ package nl.q42.template.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-object AppColorSchemeDark: AppColorScheme {
+object TemplateColorSchemeDark: TemplateColorScheme {
     override val buttonText: Color = White
     override val accent: Color =  PurpleGrey80
     override val textPrimary = White

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorSchemeLight.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateColorSchemeLight.kt
@@ -2,7 +2,7 @@ package nl.q42.template.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-object AppColorSchemeLight : AppColorScheme {
+object TemplateColorSchemeLight : TemplateColorScheme {
     override val buttonText: Color = White
     override val accent: Color = Purple40
     override val textPrimary = Black

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateRipples.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateRipples.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 
-val AppRippleConfiguration: RippleConfiguration
+val TemplateRippleConfiguration: RippleConfiguration
     @Composable
     @ReadOnlyComposable
     get() = RippleConfiguration(
-        color = AppTheme.colors.surfaceSelected
+        color = TemplateTheme.colors.surfaceSelected
     )
 
 val NoRippleConfiguration: RippleConfiguration
@@ -23,9 +23,9 @@ val NoRippleConfiguration: RippleConfiguration
         rippleAlpha = RippleAlpha(0.0f, 0.0f, 0.0f, 0.0f)
     )
 
-val AppRipple: Indication
+val TemplateRipple: Indication
     @Composable
     @ReadOnlyComposable
     get() = ripple(
-        color = AppTheme.colors.surfaceSelected
+        color = TemplateTheme.colors.surfaceSelected
     )

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateShapes.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateShapes.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 
 @Immutable
-data class AppShapes(
+data class TemplateShapes(
     val small: Shape = RoundedCornerShape(8.dp),
     val medium: Shape = RoundedCornerShape(16.dp),
     val large: Shape = RoundedCornerShape(20.dp)

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateTheme.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateTheme.kt
@@ -19,26 +19,26 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-import nl.q42.template.ui.compose.composables.widgets.AppSurface
+import nl.q42.template.ui.compose.composables.widgets.TemplateSurface
 
 /**
  * Generate this using: https://m2.material.io/material-theme-builder/. For more info and resources: see the
  * README file of our project.
  */
 
-private val LocalAppTypography = staticCompositionLocalOf { AppTypography() }
-private val LocalAppColorScheme = staticCompositionLocalOf<AppColorScheme> {
+private val LocalTemplateTypography = staticCompositionLocalOf { TemplateTypography() }
+private val LocalTemplateColorScheme = staticCompositionLocalOf<TemplateColorScheme> {
     // Dummy default, will be replaced for the actual tokens by the Provider
-    AppColorSchemeLight
+    TemplateColorSchemeLight
 }
-private val LocalAppShapes = staticCompositionLocalOf { AppShapes() }
+private val LocalTemplateShapes = staticCompositionLocalOf { TemplateShapes() }
 
 @Composable
-fun AppTheme(
+fun TemplateTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    typography: AppTypography = AppTheme.typography,
-    colors: AppColorScheme = AppTheme.colors,
-    shapes: AppShapes = AppTheme.shapes,
+    typography: TemplateTypography = TemplateTheme.typography,
+    colors: TemplateColorScheme = TemplateTheme.colors,
+    shapes: TemplateShapes = TemplateTheme.shapes,
     content: @Composable () -> Unit
 ) {
     // status bar color
@@ -52,13 +52,13 @@ fun AppTheme(
     }
 
     CompositionLocalProvider(
-        LocalAppTypography provides typography,
-        LocalAppColorScheme provides if (darkTheme) AppColorSchemeDark else AppColorSchemeLight,
-        LocalAppShapes provides shapes,
+        LocalTemplateTypography provides typography,
+        LocalTemplateColorScheme provides if (darkTheme) TemplateColorSchemeDark else TemplateColorSchemeLight,
+        LocalTemplateShapes provides shapes,
         /** configures the ripple for material components */
-        LocalRippleConfiguration provides AppRippleConfiguration,
+        LocalRippleConfiguration provides TemplateRippleConfiguration,
         /** needed for non-material components to have a material ripple. eg [Modifier.clickable] */
-        LocalIndication provides AppRipple,
+        LocalIndication provides TemplateRipple,
         /** merges the platform style with our type, @see [ProvideTextStyle] for more context */
         LocalTextStyle provides LocalTextStyle.current.merge(typography.body),
         LocalContentColor provides colors.textPrimary,
@@ -66,27 +66,27 @@ fun AppTheme(
     )
 }
 
-object AppTheme {
-    val typography: AppTypography
+object TemplateTheme {
+    val typography: TemplateTypography
         @Composable
         @ReadOnlyComposable
-        get() = LocalAppTypography.current
-    val colors: AppColorScheme
+        get() = LocalTemplateTypography.current
+    val colors: TemplateColorScheme
         @Composable
         @ReadOnlyComposable
-        get() = LocalAppColorScheme.current
-    val shapes: AppShapes
+        get() = LocalTemplateColorScheme.current
+    val shapes: TemplateShapes
         @Composable
         @ReadOnlyComposable
-        get() = LocalAppShapes.current
+        get() = LocalTemplateShapes.current
 }
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun PreviewAppTheme(content: @Composable () -> Unit) {
-    AppTheme {
+fun PreviewTemplateTheme(content: @Composable () -> Unit) {
+    TemplateTheme {
         Scaffold {
-            AppSurface {
+            TemplateSurface {
                 content()
             }
         }

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateTypography.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/TemplateTypography.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.sp
 val defaultFontFamily = FontFamily.Default
 
 @Immutable
-data class AppTypography(
+data class TemplateTypography(
     // The names of these styles are shared with your team's design system
     // So it is easy to communicate with designers about what text style to use
 

--- a/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
@@ -16,10 +16,10 @@ import nl.q42.template.ui.compose.composables.text.BodyText
 import nl.q42.template.ui.compose.composables.widgets.TemplateButton
 import nl.q42.template.ui.compose.get
 import nl.q42.template.ui.presentation.toViewStateString
-import nl.q42.template.ui.theme.AppTheme
 import nl.q42.template.ui.theme.Dimens
-import nl.q42.template.ui.theme.PreviewAppTheme
 import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewTemplateTheme
+import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
 internal fun HomeContent(
@@ -42,7 +42,7 @@ internal fun HomeContent(
         viewState.userEmailTitle?.get()?.let { Text(text = it) }
 
         if (viewState.isLoading) CircularProgressIndicator()
-        if (viewState.showError) BodyText("Error", AppTheme.colors.error)
+        if (viewState.showError) BodyText("Error", TemplateTheme.colors.error)
 
         Spacer(Modifier.height(Dimens.componentSpacingVertical))
 
@@ -65,7 +65,7 @@ internal fun HomeContent(
 @PreviewLightDark
 @Composable
 private fun HomeContentErrorPreview() {
-    PreviewAppTheme {
+    PreviewTemplateTheme {
         HomeContent(HomeViewState(showError = true), {}, {}, {})
     }
 }
@@ -73,7 +73,7 @@ private fun HomeContentErrorPreview() {
 @PreviewLightDark
 @Composable
 private fun HomeContentLoadingPreview() {
-    PreviewAppTheme {
+    PreviewTemplateTheme {
         HomeContent(HomeViewState(isLoading = true), {}, {}, {})
     }
 }
@@ -81,7 +81,7 @@ private fun HomeContentLoadingPreview() {
 @PreviewLightDark
 @Composable
 private fun HomeContentEmptyPreview() {
-    PreviewAppTheme {
+    PreviewTemplateTheme {
         HomeContent(HomeViewState(userEmailTitle = "preview@preview.com".toViewStateString()), {}, {}, {})
     }
 }


### PR DESCRIPTION
## Why is this important?
Izadi wondered where the line is drawn between Template and App. Indeed, in some projects we removed this distinction and we have `<ProjectName>Theme`. Let's put this in the template project
## Notes
