### PR TITLE
CHANGE publish action name to be non-confusing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release Builds
+name: Publish Prod Build to App Distribution
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
fix/publish-and-release-workflows--have-same-name

## Why is this important?
There are currently two workflows with the same name. That did not help while figuring out https://github.com/Q42/Template.Android/issues/81 
## Notes
