### PR TITLE
ADD extra previews for accesibility & polish

### DIFF
--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/BodyText.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/BodyText.kt
@@ -3,7 +3,7 @@ package nl.q42.template.ui.compose.composables.text
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewAll
 import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
@@ -16,7 +16,7 @@ fun BodyText(text: String, color: Color = TemplateTheme.colors.textPrimary) {
 }
 
 @Composable
-@PreviewLightDark
+@PreviewAll
 private fun BodyTextPreview() {
     TemplateTheme {
         BodyText("Body text")

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/H1Text.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/text/H1Text.kt
@@ -3,7 +3,7 @@ package nl.q42.template.ui.compose.composables.text
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewAll
 import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
@@ -16,7 +16,7 @@ fun H1Text(text: String, color: Color = TemplateTheme.colors.textPrimary) {
 }
 
 @Composable
-@PreviewLightDark
+@PreviewAll
 private fun H1TextPreview() {
     TemplateTheme {
         H1Text("H1 text")

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateButton.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateButton.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewAll
 import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
@@ -28,7 +28,7 @@ fun TemplateButton(text: String, enabled: Boolean = true, onClick: () -> Unit) {
 }
 
 @Composable
-@PreviewLightDark
+@PreviewAll
 private fun TemplateButtonPreview() {
     TemplateTheme {
         TemplateButton("Button",) {}

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateSurface.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/compose/composables/widgets/TemplateSurface.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewAll
 import nl.q42.template.ui.theme.TemplateTheme
 
 @Composable
@@ -18,7 +18,7 @@ fun TemplateSurface(modifier: Modifier = Modifier, content: @Composable () -> Un
 }
 
 @Composable
-@PreviewLightDark
+@PreviewAll
 private fun TemplateSurfacePreview() {
     TemplateTheme {
         TemplateSurface(Modifier.fillMaxSize()) {}

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/PreviewAnnotations.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/PreviewAnnotations.kt
@@ -1,17 +1,16 @@
 package nl.q42.template.ui.theme
 
-import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.content.res.Configuration.UI_MODE_TYPE_NORMAL
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
 
-@Preview(
-    name = "Dark",
-    showBackground = true,
-    uiMode = UI_MODE_NIGHT_YES
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.FUNCTION
 )
-@Preview(
-    name = "Light",
-    showBackground = true,
-    uiMode = UI_MODE_NIGHT_NO
-)
-annotation class PreviewLightDark
+@PreviewFontScale
+@Preview(name = "Dark", uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL)
+@Preview(showBackground = true, locale = "fr", name = "French")
+annotation class PreviewAll

--- a/core/ui/src/main/kotlin/nl/q42/template/ui/theme/PreviewAnnotations.kt
+++ b/core/ui/src/main/kotlin/nl/q42/template/ui/theme/PreviewAnnotations.kt
@@ -10,7 +10,8 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
     AnnotationTarget.ANNOTATION_CLASS,
     AnnotationTarget.FUNCTION
 )
-@PreviewFontScale
-@Preview(name = "Dark", uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL)
-@Preview(showBackground = true, locale = "fr", name = "French")
+@Preview(name = "85% Dark", fontScale = 0.85f, uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL)
+@Preview(name = "100% Light", fontScale = 1f, uiMode = UI_MODE_TYPE_NORMAL)
+@Preview(name = "150%", fontScale = 1.5f)
+@Preview(name = "200%", fontScale = 2f)
 annotation class PreviewAll

--- a/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
+++ b/feature/home/src/main/kotlin/nl/q42/template/home/main/ui/HomeContent.kt
@@ -17,7 +17,7 @@ import nl.q42.template.ui.compose.composables.widgets.TemplateButton
 import nl.q42.template.ui.compose.get
 import nl.q42.template.ui.presentation.toViewStateString
 import nl.q42.template.ui.theme.Dimens
-import nl.q42.template.ui.theme.PreviewLightDark
+import nl.q42.template.ui.theme.PreviewAll
 import nl.q42.template.ui.theme.PreviewTemplateTheme
 import nl.q42.template.ui.theme.TemplateTheme
 
@@ -65,7 +65,7 @@ internal fun HomeContent(
     }
 }
 
-@PreviewLightDark
+@PreviewAll
 @Composable
 private fun HomeContentErrorPreview() {
     PreviewTemplateTheme {
@@ -73,7 +73,7 @@ private fun HomeContentErrorPreview() {
     }
 }
 
-@PreviewLightDark
+@PreviewAll
 @Composable
 private fun HomeContentLoadingPreview() {
     PreviewTemplateTheme {
@@ -81,7 +81,7 @@ private fun HomeContentLoadingPreview() {
     }
 }
 
-@PreviewLightDark
+@PreviewAll
 @Composable
 private fun HomeContentEmptyPreview() {
     PreviewTemplateTheme {


### PR DESCRIPTION
## Why is this important?
instead of simply using compose's `PreviewLightDark` as the issue #103 suggests, i thought that it might be better to instead add more previews to that custom preview annotation that we have. this way we can directly check accessibility issues on bigger fonts, locales etc

using our own annotation also allows us to modify all the previews in the app directly in case in the future we want to add a new language preview or anything in particular instead of having to add to every single preview

## Notes
right now french preview has the same strings as english, but i thought that it was nice to leave it there as a reminder that different locale previews are possible

fixes #103 