### PR TITLE
Add dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#gradle
+name: Dependency Submission
+
+run-name: Running Dependency Submission
+
+on:
+    workflow_dispatch:
+    workflow_call:
+
+permissions:
+    contents: write
+
+jobs:
+    dependency-submission:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v4
+            - name: Setup Java
+              uses: actions/setup-java@v4
+              with:
+                  distribution: "temurin"
+                  java-version: 17
+            - name: Generate and submit dependency graph
+              uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
## Why is this important?

We want to be informed of vulnerabilities in our dependencies

See: https://github.com/Q42/PostNL.Android/pull/3612

## Notes

- PostNL dependency graph: https://github.com/Q42/PostNL.Android/network/dependencies
- https://q42.slack.com/archives/C02BT66BX/p1744019977749909?thread_ts=1743831612.075389&cid=C02BT66BX
- https://github.com/gradle/actions/blob/main/dependency-submission/README.md 