### PR TITLE
FIX enableEdgeToEdge call order

### DIFF
--- a/app/src/main/kotlin/nl/q42/template/MainActivity.kt
+++ b/app/src/main/kotlin/nl/q42/template/MainActivity.kt
@@ -29,11 +29,11 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge() // must be called before super.onCreate
         super.onCreate(savedInstanceState)
 
         Napier.d { "onCreate received, ${intent.data}" }
 
-        enableEdgeToEdge()
 
         setContent {
 


### PR DESCRIPTION
fix/enable-edge-to-edge

## Why is this important?
- doesn't really seem to have an effect for us, but docs say this is the correct call order: https://developer.android.com/develop/ui/views/layout/edge-to-edge#enable-edge-to-edge-display

## Notes
