### PR TITLE
FIX crashlytics dependency artifact

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ composeUIToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview" }
 composeMaterial3 = { module = "androidx.compose.material3:material3" }
 composePlatform = { module = "androidx.compose:compose-bom", version.ref = "composePlatform" }
 firebaseBoM = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBOM" }
-firebaseCrashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebaseCrashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 activityCompose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 composeLifecycle = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecycle" }


### PR DESCRIPTION
## Why is this important?
Crashlytics has been stuck on an old version because Kotlin support has been moved to the main dependency

https://firebase.google.com/docs/android/kotlin-migration

## Notes
