### PR TITLE
CHANGE catch Throwable instead of Exception

### DIFF
--- a/core/actionresult/src/main/kotlin/nl/q42/template/actionresult/data/ActionResultMapper.kt
+++ b/core/actionresult/src/main/kotlin/nl/q42/template/actionresult/data/ActionResultMapper.kt
@@ -25,8 +25,8 @@ private fun isTooManyRequests(httpStatusCode: Int?) = httpStatusCode == TOO_MANY
 suspend fun <T : Any> mapToActionResult(request: suspend () -> NetworkResponse<T, ApiErrorResponse>): ActionResult<T> =
     try {
         request().networkResponseToActionResult()
-    } catch (e: Exception) {
-        if (e is CancellationException) ActionResult.Error.Cancelled(e) else ActionResult.Error.Other(e)
+    } catch (t: Throwable) {
+        if (t is CancellationException) ActionResult.Error.Cancelled(t) else ActionResult.Error.Other(t)
     }
 
 private fun <T : Any> NetworkResponse<T, ApiErrorResponse>.networkResponseToActionResult(): ActionResult<T> =

--- a/core/actionresult/src/main/kotlin/nl/q42/template/actionresult/domain/ActionResult.kt
+++ b/core/actionresult/src/main/kotlin/nl/q42/template/actionresult/domain/ActionResult.kt
@@ -5,29 +5,29 @@ sealed class ActionResult<out T : Any?> {
     /**
      * An error class used so that feature modules can give an exact error message to the user.
      */
-    sealed class Error(open val exception: Exception) : ActionResult<Nothing>() {
+    sealed class Error(open val throwable: Throwable) : ActionResult<Nothing>() {
 
-        data class UnAuthorized(override val exception: Exception, val message: String?) : Error(exception)
+        data class UnAuthorized(override val throwable: Throwable, val message: String?) : Error(throwable)
 
-        data class TooManyRequests(override val exception: Exception) : Error(exception)
+        data class TooManyRequests(override val throwable: Throwable) : Error(throwable)
 
-        data class Cancelled(override val exception: Exception) : Error(exception)
+        data class Cancelled(override val throwable: Throwable) : Error(throwable)
 
         data class InvalidErrorResponse(
-            override val exception: Exception = Exception("API error format is invalid"),
+            override val throwable: Throwable = Throwable("API error format is invalid"),
             val httpStatusCode: Int? = null
         ) :
-            Error(exception)
+            Error(throwable)
 
-        data class ServerError(override val exception: Exception, val message: String) : Error(exception)
+        data class ServerError(override val throwable: Throwable, val message: String) : Error(throwable)
 
         data object NotFoundError : Error(Exception("404: Not Found"))
 
-        data class NetworkError(override val exception: Exception) : Error(exception)
+        data class NetworkError(override val throwable: Throwable) : Error(throwable)
 
-        data class Other(override val exception: Exception) : Error(exception)
+        data class Other(override val throwable: Throwable) : Error(throwable)
 
-        data object NotImplemented : Error(Exception("API error format not implemented"))
+        data object NotImplemented : Error(Throwable("API error format not implemented"))
     }
 
     data class Success<T : Any?>(val data: T) : ActionResult<T>()

--- a/data/main/src/main/kotlin/nl/q42/template/data/main/remote/UserRemoteDataSource.kt
+++ b/data/main/src/main/kotlin/nl/q42/template/data/main/remote/UserRemoteDataSource.kt
@@ -28,7 +28,7 @@ internal class UserRemoteDataSource @Inject constructor(
             }
 
             is ActionResult.Error -> {
-                Napier.e(apiActionResult.exception) { "getUser failed" }
+                Napier.e(apiActionResult.throwable) { "getUser failed" }
                 apiActionResult
             }
         }


### PR DESCRIPTION
## Why is this important?
There are some errors that are Throwables but not Exceptions. These need to be handled too. I had this happen af few times in my projects.

## Notes
It seems catching exception is not idiomatic and bad practice in Kotlin: https://stackoverflow.com/a/64323675/923557
