### PR TITLE
Add check for allowed licenses in dependencies

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check licenses of dependencies are valid
+        run: ./gradlew licensee
+
       - name: Build Debug APK
         run: ./gradlew assembleDevDebug --stacktrace
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /.idea/assetWizardSettings.xml
 /.idea/AndroidProjectSystem.xml
 /.idea/kotlinc.xml
+/.idea/appInsightsSettings.xml
+/.idea/copilot.data.migration.ask2agent.xml
+/.idea/material_theme_project_new.xml
 .DS_Store
 /build
 /captures

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias libs.plugins.googleServices
     alias libs.plugins.firebaseCrashlyticsPlugin
     alias libs.plugins.compose.compiler
+    id("app.cash.licensee")
 }
 
 if (file("$rootDir/secrets.gradle").exists()) {
@@ -118,4 +119,14 @@ tasks.register("checkSigningConfig") {
 // Attach checkSigningConfig to all release variant preBuild tasks
 tasks.matching { it.name =~ /assemble.*Release/ }.configureEach { task ->
     task.dependsOn("checkSigningConfig")
+}
+
+licensee { // A gradle task "./gradlew licensee" checks the licenses of your dependencies and fails when a disallowed license is found.
+    allow("Apache-2.0")
+    allow("BSD-3-Clause")
+    allow("MIT")
+    allowUrl("https://developer.android.com/studio/terms.html")
+    allowDependency('com.github.leonard-palm', 'compose-state-events', '2.2.0') {
+        because 'Apache-2.0, but license in this version of the lib is not recognized by Licensee'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ buildscript {
         targetSdkVersion = 36
         compileSdkVersion = 36
     }
+    dependencies {
+        classpath(libs.plugin.licensee)
+    }
 }
 
 plugins { // sets class paths only (because of 'apply false')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ composeNavigation = { module = "androidx.navigation:navigation-compose", version
 koin = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
-plugin-licensee = { module = "app.cash.licensee:licensee-gradle-plugin", version.ref = "licensee" }
+plugin-licensee = { module = "app.cash.licensee:licensee-gradle-plugin", version.ref = "licensee" } # Gradle plugin that is used in build-logic (classpath), and cannot be put in the [plugins] block below
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ mockkAndroid = "1.14.6"
 turbine = "1.2.1"
 composeStateEvents = "2.2.0"
 koin = "4.1.1"
+licensee = "1.14.1"
 
 [libraries]
 junit = { module = "junit:junit", version.ref = "junit" }
@@ -52,6 +53,7 @@ composeNavigation = { module = "androidx.navigation:navigation-compose", version
 koin = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
+plugin-licensee = { module = "app.cash.licensee:licensee-gradle-plugin", version.ref = "licensee" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradlePlugin" }


### PR DESCRIPTION
## Why is this important?
To make sure we don't ship apps with problematic/dangerous dependencies.

## Notes
New gradle task `./gradlew licensee` checks in CI if all dependencies (and transitive dependencies) have allowed licenses