### PR TITLE
Fix Napier Debug Antilog issue

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,8 @@
 }
 
 ## END enums
+
+## START napier
+-keep class io.github.aakira.napier.* {
+    *;
+}

--- a/app/src/main/kotlin/nl/q42/template/logging/CrashlyticsLogger.kt
+++ b/app/src/main/kotlin/nl/q42/template/logging/CrashlyticsLogger.kt
@@ -13,6 +13,7 @@ import io.github.aakira.napier.Napier
  * In theory, the message sent to Crashlytics could therefore be 2x this value
  */
 private const val MAX_CHARS_IN_LOG = 1200
+private const val DEFAULT_TAG = "AppLogger"
 
 /** A Crashlytics logger. The name Antilog might be an unfortunate choice by the Napier library;
  * this is not a stub
@@ -26,18 +27,10 @@ class CrashlyticsLogger : Antilog() {
     ) {
         if (message == null && throwable == null) return
 
-        if (BuildConfig.DEBUG || priority > LogLevel.DEBUG) {
-            // also send to logcat
-            val logLevel = priority.toAndroidLogLevel()
-            val logMessage = buildString {
-                if (message != null) append(message)
-                if (throwable != null) {
-                    if (message != null) append("\n")
-                    append(Log.getStackTraceString(throwable))
-                }
-            }
+        val safeTag = tag ?: DEFAULT_TAG
 
-            Log.println(logLevel, tag ?: "AppLogger", logMessage)
+        if (BuildConfig.DEBUG || priority > LogLevel.DEBUG) {
+            logToLogcat(priority, safeTag, message, throwable)
         }
 
         val limitedMessage = message?.take(MAX_CHARS_IN_LOG) ?: "(no message)" // to avoid OutOfMemoryError's
@@ -50,7 +43,29 @@ class CrashlyticsLogger : Antilog() {
             Firebase.crashlytics.log(limitedMessage + errorMessage)
         } else {
             Firebase.crashlytics.log("recordException with message: $limitedMessage")
-            Firebase.crashlytics.recordException(throwable ?: buildCrashlyticsSyntheticException(limitedMessage))
+            Firebase.crashlytics.recordException(
+                throwable ?: buildCrashlyticsSyntheticException(
+                    limitedMessage,
+                    safeTag
+                )
+            )
+        }
+    }
+
+    private fun logToLogcat(
+        priority: LogLevel,
+        tag: String,
+        message: String?,
+        throwable: Throwable?
+    ) {
+        val msg = message ?: ""
+        when (priority) {
+            LogLevel.VERBOSE -> Log.v(tag, msg, throwable)
+            LogLevel.DEBUG -> Log.d(tag, msg, throwable)
+            LogLevel.INFO -> Log.i(tag, msg, throwable)
+            LogLevel.WARNING -> Log.w(tag, msg, throwable)
+            LogLevel.ERROR -> Log.e(tag, msg, throwable)
+            LogLevel.ASSERT -> Log.wtf(tag, msg, throwable)
         }
     }
 
@@ -60,36 +75,22 @@ class CrashlyticsLogger : Antilog() {
      * This is a workaround for the fact that Crashlytics groups errors by stacktrace
      * [https://stackoverflow.com/a/59779764](https://stackoverflow.com/a/59779764)
      */
-    private fun buildCrashlyticsSyntheticException(message: String): Exception {
+    private fun buildCrashlyticsSyntheticException(message: String, tag: String): Exception {
         val stackTrace = Thread.currentThread().stackTrace
         val numToRemove = 9
         val lastToRemove = stackTrace.getOrNull(numToRemove - 1)
         if (lastToRemove == null) {
-            Log.e(
-                null,
-                "Got unexpected stacktrace while logging a message: ${stackTrace.contentToString()}"
-            )
+            Log.e(tag, "Got unexpected stacktrace while logging a message: ${stackTrace.contentToString()}")
             return SyntheticException(message, stackTrace)
         }
         if (lastToRemove.className != Napier::class.java.name || lastToRemove.methodName != "e\$default") {
             Log.e(
-                null,
+                tag,
                 "Got unexpected stacktrace: class: ${lastToRemove.className}, method: ${lastToRemove.methodName}"
             )
         }
         val abbreviatedStackTrace = stackTrace.takeLast(stackTrace.size - numToRemove).toTypedArray()
         return SyntheticException(message, abbreviatedStackTrace)
-    }
-
-    private fun LogLevel.toAndroidLogLevel(): Int {
-        return when (this) {
-            LogLevel.VERBOSE -> Log.VERBOSE
-            LogLevel.DEBUG -> Log.DEBUG
-            LogLevel.INFO -> Log.INFO
-            LogLevel.WARNING -> Log.WARN
-            LogLevel.ERROR -> Log.ERROR
-            LogLevel.ASSERT -> Log.ASSERT
-        }
     }
 }
 

--- a/app/src/main/kotlin/nl/q42/template/logging/CrashlyticsLogger.kt
+++ b/app/src/main/kotlin/nl/q42/template/logging/CrashlyticsLogger.kt
@@ -1,11 +1,12 @@
 package nl.q42.template.logging
 
+import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.crashlytics
 import io.github.aakira.napier.Antilog
-import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.LogLevel
 import nl.q42.template.BuildConfig
+import io.github.aakira.napier.Napier
 
 /** A value suitable for Crashlytics
  * This value is used to truncate the user-defined message and the exception message
@@ -17,9 +18,6 @@ private const val MAX_CHARS_IN_LOG = 1200
  * this is not a stub
  */
 class CrashlyticsLogger : Antilog() {
-
-    private val logcatLogger = DebugAntilog()
-
     override fun performLog(
         priority: LogLevel,
         tag: String?,
@@ -30,10 +28,19 @@ class CrashlyticsLogger : Antilog() {
 
         if (BuildConfig.DEBUG || priority > LogLevel.DEBUG) {
             // also send to logcat
-            logcatLogger.log(priority, tag, throwable, message)
+            val logLevel = priority.toAndroidLogLevel()
+            val logMessage = buildString {
+                if (message != null) append(message)
+                if (throwable != null) {
+                    if (message != null) append("\n")
+                    append(Log.getStackTraceString(throwable))
+                }
+            }
+
+            Log.println(logLevel, tag ?: "AppLogger", logMessage)
         }
 
-        val limitedMessage = message?.take(MAX_CHARS_IN_LOG)  ?: "(no message)" // to avoid OutOfMemoryError's
+        val limitedMessage = message?.take(MAX_CHARS_IN_LOG) ?: "(no message)" // to avoid OutOfMemoryError's
 
         // at least one of message or throwable is not null
         if (priority < LogLevel.ERROR) {
@@ -58,25 +65,37 @@ class CrashlyticsLogger : Antilog() {
         val numToRemove = 9
         val lastToRemove = stackTrace.getOrNull(numToRemove - 1)
         if (lastToRemove == null) {
-            logcatLogger.log(priority = LogLevel.ERROR, tag = null, throwable = null,
-                    message = "Got unexpected stacktrace while logging a message: ${stackTrace.contentToString()}"
+            Log.e(
+                null,
+                "Got unexpected stacktrace while logging a message: ${stackTrace.contentToString()}"
             )
             return SyntheticException(message, stackTrace)
         }
-        if (lastToRemove.className != io.github.aakira.napier.Napier::class.java.name || lastToRemove.methodName != "e\$default"){
-            logcatLogger.log(priority = LogLevel.ERROR, tag = null, throwable = null,
-                    message = "Got unexpected stacktrace: class: ${lastToRemove.className}, method: ${lastToRemove.methodName}"
+        if (lastToRemove.className != Napier::class.java.name || lastToRemove.methodName != "e\$default") {
+            Log.e(
+                null,
+                "Got unexpected stacktrace: class: ${lastToRemove.className}, method: ${lastToRemove.methodName}"
             )
         }
         val abbreviatedStackTrace = stackTrace.takeLast(stackTrace.size - numToRemove).toTypedArray()
         return SyntheticException(message, abbreviatedStackTrace)
     }
 
+    private fun LogLevel.toAndroidLogLevel(): Int {
+        return when (this) {
+            LogLevel.VERBOSE -> Log.VERBOSE
+            LogLevel.DEBUG -> Log.DEBUG
+            LogLevel.INFO -> Log.INFO
+            LogLevel.WARNING -> Log.WARN
+            LogLevel.ERROR -> Log.ERROR
+            LogLevel.ASSERT -> Log.ASSERT
+        }
+    }
 }
 
 class SyntheticException(
-        message: String,
-        private val abbreviatedStackTrace: Array<StackTraceElement>
+    message: String,
+    private val abbreviatedStackTrace: Array<StackTraceElement>
 ) : Exception(message) {
     override fun getStackTrace(): Array<StackTraceElement> {
         return abbreviatedStackTrace


### PR DESCRIPTION
⚠️ Updated here  https://github.com/Q42/Template.Android/pull/198

## Why is this important?

This issue causes applications to crash: https://github.com/AAkira/Napier/issues/132

## Notes

- We no longer use DebugAntilog in CrashlyticsLogger, we use more transparent syntax + get rid of the dependency on DebugAntilog. The error occurred because DebugAntilog was apparently not intended for the release mode and was removed or not added to the proguard rules
- I also added a rule for napier to the proguard rules. Just to be on the safe side and to prevent the app from crashing due to the logging library